### PR TITLE
fix redirection

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
vercel n'aimait pas les redirections faite en dur dans l'url.

Un fichier de configuration était nécessaire